### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -2,7 +2,6 @@ class ProductsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
 
   def index
-    @products = Product.all
     @products = Product.includes(:user).order("created_at DESC")
   end
 

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,7 +1,8 @@
 class ProductsController < ApplicationController
-  before_action :authenticate_user!, except: [:index]
+  before_action :authenticate_user!, except: [:index, :show]
 
   def index
+    @products = Product.all
     @products = Product.includes(:user).order("created_at DESC")
   end
 
@@ -17,6 +18,10 @@ class ProductsController < ApplicationController
       render :new
     end
   end
+
+def show
+  @product = Product.find(params[:id])
+end
 
   private
 

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -22,6 +22,10 @@ def show
   @product = Product.find(params[:id])
 end
 
+def edit
+  @product = Product.find(params[:id])
+end
+
   private
 
   def product_params

--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -1,2 +1,0 @@
-module ItemsHelper
-end

--- a/app/views/products/edit.html.erb
+++ b/app/views/products/edit.html.erb
@@ -7,7 +7,7 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with model:@product,local: true do |f| %>
+    <%#= form_with model:@product,local: true do |f| %>
 
     <% render 'shared/error_messages', model: f.object %>
     

--- a/app/views/products/edit.html.erb
+++ b/app/views/products/edit.html.erb
@@ -7,7 +7,7 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with model:@product,local: true do |f| %>
 
     <% render 'shared/error_messages', model: f.object %>
     

--- a/app/views/products/edit.html.erb
+++ b/app/views/products/edit.html.erb
@@ -7,7 +7,7 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%#= form_with model:@product,local: true do |f| %>
+    <%= form_with model:@product,local: true do |f| %>
 
     <% render 'shared/error_messages', model: f.object %>
     

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -158,7 +158,7 @@
 
       <% if @products.blank? then %>
       <li class='list'>
-        <%= link_to product_path (product) do %>
+        <%#= link_to product_path (product) do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
         <div class='item-info'>
           <h3 class='item-name'>
@@ -172,7 +172,7 @@
             </div>
           </div>
         </div>
-        <% end %>
+        <%# end %>
       </li>
       <% end %>
     </ul>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -128,11 +128,11 @@
     </div>
     <ul class='item-lists'>
 
-      <% @products.each do |item| %>
+      <% @products.each do |product| %>
       <li class='list'>
-        <%#= link_to product_path(item) do %>
+        <%= link_to product_path (product.id) do %>
         <div class='item-img-content'>
-          <%= image_tag item.image.variant(resize: '500x500'), class: "item-img" if item.image.attached? %>
+          <%= image_tag product.image.variant(resize: '500x500'), class: "item-img" if product.image.attached? %>
 
           <%# if item.item_purchase.present? %>
           <%#div class='sold-out'>
@@ -144,7 +144,7 @@
             <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= item.price %>円<br><%= item.cost.name %></span>
+            <span><%= product.price %>円<br><%= product.cost.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -152,13 +152,13 @@
           </div>
         </div>
           <%# end %>
-        <%# end %>
+        <% end %>
       </li>
       <% end %>
 
       <% if @products.blank? then %>
       <li class='list'>
-        <%= link_to '#' do %>
+        <%= link_to product_path (product) do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
         <div class='item-info'>
           <h3 class='item-name'>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -158,7 +158,7 @@
 
       <% if @products.blank? then %>
       <li class='list'>
-        <%#= link_to product_path (product) do %>
+        <%= link_to "#" do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
         <div class='item-info'>
           <h3 class='item-name'>
@@ -172,7 +172,7 @@
             </div>
           </div>
         </div>
-        <%# end %>
+        <% end %>
       </li>
       <% end %>
     </ul>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -4,10 +4,10 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @product.name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @product.image.variant(resize: '500x500'), class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class="sold-out">
         <span>Sold Out!!</span>
@@ -16,23 +16,27 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= @product.price %>円
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @product.cost.name %>
       </span>
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
+  <% if user_signed_in? %>
+    <% if current_user.id == @product.user.id %>
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
 
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
+    <% else%>
 
+    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+
+    <% end %>
+
+  <% end %>
 
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
@@ -43,27 +47,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @product.user.nick_name %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @product.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @product.status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @product.cost.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @product.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @product.delivery_days.name %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -106,9 +106,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+  <a href="#" class="another-item"><%= @product.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -23,22 +23,19 @@
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
   <% if user_signed_in? %>
     <% if current_user.id == @product.user.id %>
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-
+    <%# 商品が売れていない場合はこちらを表示しましょう %>
     <% else%>
-
+    <%#  //商品が売れていない場合はこちらを表示しましょう %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
 
     <% end %>
 
   <% end %>
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
       <span><%= "商品説明" %></span>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -38,7 +38,7 @@
   <% end %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @product.description %></span>
     </div>
     <table class="detail-table">
       <tbody>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -25,7 +25,7 @@
 
   <% if user_signed_in? %>
     <% if current_user.id == @product.user.id %>
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+    <%= link_to "商品の編集", edit_product_path, method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -1,9 +1,0 @@
-require 'test_helper'
-
-class ItemsControllerTest < ActionDispatch::IntegrationTest
-  test "should get index" do
-    get items_index_url
-    assert_response :success
-  end
-
-end


### PR DESCRIPTION
#What
商品詳細表示機能の実装。
#Why
商品の一詳細表示を可能にするため。

ログアウト中でも詳細ページに遷移できる動画
[https://gyazo.com/8aef4d28220866554458fe859dc6702d](url)
ログイン中で商品詳細ページに遷移できる動画
[https://gyazo.com/42d74eaaacc29cac73d3481d236ee29a](url)
ログイン中自身が出品していない商品の詳細ページに遷移する動画
[https://gyazo.com/a03b0cf68e467295aaf9d32d4a6b286a](url)

よろしくお願いします。
